### PR TITLE
Integrate TrustForge in pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ flowchart TD
 
 - **Ollama Scraper**: Harvests raw model data, including tags, manifests, and configuration files.
 - **RECURSOR-1**: Normalizes fields, infers missing data, and leverages LLMs for comprehensive enrichment.
-- **TrustForge**: Computes trust scores by fusing heuristic metrics from multiple data sources.
+- **TrustForge**: Computes trust scores by fusing heuristic metrics from multiple data sources and now runs automatically inside the enrichment pipeline.
 - **TracePoint**: Tracks enrichment lineage, prompt decision paths, and source deltas for transparent provenance.
 - **AtlasView**: A web-based dashboard enabling search, filtering, comparative analysis, and visual audits.
 
@@ -126,11 +126,8 @@ modelatlas/
 ## 🧪 Example Commands
 
 ```bash
-# Enrich all scraped models recursively
+# Run enrichment pipeline (includes trust scoring)
 python enrich/main.py
-
-# Compute trust scores for all models
-python trustforge/score.py
 
 # Perform semantic search for multilingual open-license models
 atlas search "multilingual open license"

--- a/enrich/main.py
+++ b/enrich/main.py
@@ -1,0 +1,49 @@
+"""Simple enrichment pipeline that merges manual metadata and computes trust scores."""
+
+import glob
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from trustforge import compute_score
+
+MODELS_DIR = "models"
+ENRICHED_OUTPUTS_DIR = "enriched_outputs"
+OUTPUT_FILE = "models_enriched.json"
+
+
+def load_base_model(path: str) -> Dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_manual_enrichment(name: str) -> Dict:
+    enriched_path = os.path.join(ENRICHED_OUTPUTS_DIR, f"{name}_enriched.json")
+    if os.path.exists(enriched_path):
+        try:
+            with open(enriched_path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            pass
+    return {}
+
+
+def main() -> None:
+    models: List[Dict] = []
+    for path in glob.glob(os.path.join(MODELS_DIR, "*.json")):
+        base = load_base_model(path)
+        name_slug = base.get("name", "").replace("/", "_")
+        enrichment = load_manual_enrichment(name_slug)
+        base.update(enrichment)
+        base["trust_score"] = compute_score(base)
+        models.append(base)
+
+    with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
+        json.dump(models, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks.yml
+++ b/tasks.yml
@@ -325,7 +325,7 @@
   component: "Pipeline"
   dependencies: [3]
   priority: 3
-  status: "pending"
+  status: "done"
 
 - id: 14
   title: "Standardize RECURSOR naming"

--- a/tasks/tasklog-13-integrate-trustforge-in-pipeline.md
+++ b/tasks/tasklog-13-integrate-trustforge-in-pipeline.md
@@ -1,0 +1,8 @@
+# Task 13: Integrate TrustForge in pipeline
+
+## Summary
+Implemented a simple TrustForge module and wired it into a new `enrich/main.py` pipeline script. The pipeline merges manual enrichment outputs with base model data and computes a trust score for each model. README and tasks.yml updated to reflect the integrated workflow.
+
+## Notes
+- Trust scores are based on license type and download counts using basic heuristics.
+- The old standalone `trustforge/score.py` can still be executed directly, but running `python enrich/main.py` now performs all steps in one command.

--- a/trustforge/__init__.py
+++ b/trustforge/__init__.py
@@ -1,0 +1,24 @@
+"""Simple TrustForge scoring heuristics."""
+
+from typing import Dict
+
+LICENSE_SCORES = {
+    "apache-2.0": 0.9,
+    "mit": 0.9,
+    "gpl-3.0": 0.6,
+    "cc-by-nc": 0.4,
+}
+
+MAX_DOWNLOADS = 10_000_000
+
+
+def compute_score(model: Dict) -> float:
+    """Compute a basic trust score for a model."""
+    license_key = str(model.get("license", "")).lower()
+    license_score = LICENSE_SCORES.get(license_key, 0.5)
+
+    downloads = model.get("downloads") or model.get("pull_count", 0)
+    downloads_score = min(downloads / MAX_DOWNLOADS, 1.0) if isinstance(downloads, (int, float)) else 0.0
+
+    score = 0.7 * license_score + 0.3 * downloads_score
+    return round(min(score, 1.0), 3)

--- a/trustforge/score.py
+++ b/trustforge/score.py
@@ -1,0 +1,49 @@
+"""Compute trust scores for model catalog."""
+
+import glob
+import json
+import os
+import sys
+from pathlib import Path
+from typing import List, Dict
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from trustforge import compute_score
+
+MODELS_DIR = "models"
+ENRICHED_OUTPUTS_DIR = "enriched_outputs"
+OUTPUT_FILE = "models_enriched.json"
+
+
+def load_model(path: str) -> Dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def merge_enrichment(model: Dict) -> Dict:
+    name = model.get("name", "").replace("/", "_")
+    enriched_path = os.path.join(ENRICHED_OUTPUTS_DIR, f"{name}_enriched.json")
+    if os.path.exists(enriched_path):
+        try:
+            with open(enriched_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            model.update(data)
+        except Exception:
+            pass
+    return model
+
+
+def main() -> None:
+    models: List[Dict] = []
+    for path in glob.glob(os.path.join(MODELS_DIR, "*.json")):
+        model = load_model(path)
+        model = merge_enrichment(model)
+        model["trust_score"] = compute_score(model)
+        models.append(model)
+
+    with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
+        json.dump(models, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- wire TrustForge heuristics into new `enrich/main.py`
- add simple scoring logic under `trustforge`
- update README example commands
- mark task 13 done and log work

## Testing
- `make -C docs html` *(fails: No rule to make target 'html')*
- `python enrich/main.py`
- `python trustforge/score.py`


------
https://chatgpt.com/codex/tasks/task_e_687865cffe5c832abe77c52783a20349