### PR TITLE
Initialize Sphinx docs site and integrate existing Markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ venv.bak/
 
 # HTML reports
 *.html
+docs/_build/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,10 @@ Examples:
 
 Run `make -C docs html` to generate the Sphinx site in `docs/build/html`.
 
+The Sphinx configuration uses `recommonmark` so Markdown files in `docs/` are
+included automatically. Add new docs as `.md` files and list them in
+`docs/index.rst`.
+
 ### Repository Hygiene
 
 The repository uses a comprehensive `.gitignore` based on common Python patterns.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,35 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'ModelAtlas'
+copyright = '2025, ModelAtlas Team'
+author = 'ModelAtlas Team'
+
+version = '0.1'
+release = '0.1'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ['recommonmark']
+
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown',
+}
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,25 @@
+.. ModelAtlas documentation master file, created by
+   sphinx-quickstart on Thu Jul 17 04:19:34 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+ModelAtlas documentation
+========================
+
+Add your content using ``reStructuredText`` syntax. See the
+`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
+documentation for details.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   AGENT_BRIEF
+   DOWNLOAD_METRICS
+   OLLAMA_AGENT_CANVAS
+   OLLAMA_SCRAPING_DETAILS
+   OLLAMA_UI_DEMO
+   PHASE_2_DESIGN
+   VISUALIZATION_IDEAS
+

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ rich
 jinja2
 pandas
 matplotlib
+sphinx
+recommonmark

--- a/tasks.yml
+++ b/tasks.yml
@@ -478,3 +478,10 @@
   priority: 3
   status: "done"
 
+- id: 33
+  title: "Initialize Sphinx documentation site"
+  description: "Initialize Sphinx docs site and integrate existing Markdown."
+  component: "Docs"
+  dependencies: []
+  priority: 2
+  status: "done"

--- a/tasks/tasklog-33-initialize-sphinx-documentation-site.md
+++ b/tasks/tasklog-33-initialize-sphinx-documentation-site.md
@@ -1,0 +1,7 @@
+## Task 33 - Initialize Sphinx documentation site
+
+- Ran `sphinx-quickstart` in `docs/` to generate configuration files.
+- Added Markdown support via `recommonmark` in `conf.py`.
+- Updated `index.rst` to include existing documentation files.
+- Added `sphinx` and `recommonmark` to `requirements.txt`.
+- Verified build with `make -C docs html`.


### PR DESCRIPTION
## Summary
- bootstrap Sphinx in `docs/`
- configure Markdown support via recommonmark
- list all existing docs in `index.rst`
- update `.gitignore` and requirements
- log completion of task 33

## Testing
- `make -C docs html`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68787985956c832aa471c3828fb0a253