### PR TITLE
Fix README meta documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ modelatlas/
 │   ├── schema.md
 │   ├── usage_examples.md
 │   └── PHASE_2_DESIGN.md
-├── ROADMAP.md
 ├── AGENTS.md
 ├── tasks.yml
 ├── README.md
@@ -160,10 +159,9 @@ cd dashboards && npm run dev
 |----------------------|------------------------------------------------|
 | `AGENTS.md`          | Details on enrichment agents, memory, and state logic |
 | `tasks.yml`          | Canonical task graph defining enrichment workflows |
-| `naming.md`          | Naming philosophy and conventions               |
+| `naming.md`          | Naming philosophy and conventions |
 | `schema.md`          | Data schema specification for enriched model entries |
-| `usage_examples.md`   | Real-world CLI workflows and usage patterns     |
-| `ROADMAP.md`         | Vision, milestones, and iteration plans          |
+| `usage_examples.md`  | Real-world CLI workflows and usage patterns |
 | `PHASE_2_DESIGN.md`  | Design notes on manifest decoding, tag repair, and scoring implementation |
 
 ⸻

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -1,0 +1,10 @@
+# Naming Conventions
+
+This project uses a consistent naming style across code and documentation.
+
+- **PascalCase** for class names.
+- **snake_case** for functions and variables.
+- Hyphenated lower-case for CLI commands.
+
+These guidelines keep the codebase readable and predictable.
+

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,0 +1,13 @@
+# Data Schema Overview
+
+The enrichment pipeline outputs model metadata that conforms to a simple JSON schema.
+
+Key fields include:
+
+- `name`: model identifier
+- `version`: tag or release string
+- `license`: license name
+- `downloads`: integer download count
+
+See `schemas/model.schema.json` for the authoritative specification.
+

--- a/docs/usage_examples.md
+++ b/docs/usage_examples.md
@@ -1,0 +1,12 @@
+# Usage Examples
+
+The CLI provides quick access to search and metadata enrichment features.
+
+```bash
+# Fetch the latest metadata
+python enrich/main.py --limit 10
+
+# Search for models matching a term
+atlas-cli search llama
+```
+


### PR DESCRIPTION
## Summary
- restore meta-docs in README with naming, schema, and usage docs
- add placeholder docs so table links work
- build sphinx docs and run parse helper tests

## Testing
- `make -C docs html`
- `python tools/test_parse_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_68787b615858832aa3ab85fe7e158d0c