### PR TITLE
Enable caching for scrapers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ To ensure "granularity, God-mode logging, and recursive agent intelligence" acro
 
 1.  **Fetch:** Agents will use `playwright` to programmatically access and retrieve the raw HTML content of target web pages. This ensures handling of dynamically loaded content.
     *   **Logging:** For every page fetch, log the `fetched_url`, `timestamp`, and `HTTP status` to a dedicated log file (e.g., `ollama_scraper.log`).
+    *   **Caching:** HTTP responses are cached in `.cache/http.sqlite` via `requests-cache`. Use the `--no-cache` flag to disable.
 
 2.  **Parse:** Agents will use `BeautifulSoup` to parse the fetched HTML content, extracting structured data based on predefined CSS selectors and regular expressions. This step will involve:
     *   Identifying model listings on search/library pages.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ tracepoint gemma:2b --lineage
 cd dashboards && npm run dev
 ```
 
+All HTTP requests made by the scrapers are cached in `.cache/http.sqlite` by default. Use `--no-cache` to disable caching.
+
 ## 📦 Git LFS Setup
 
 This repository uses [Git LFS](https://git-lfs.com/) to version large JSON artifacts. Run the following commands after cloning:

--- a/atlas_schemas/config.py
+++ b/atlas_schemas/config.py
@@ -1,5 +1,6 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pathlib import Path
+from typing import Optional
 
 class Config(BaseSettings):
     """Centralized configuration for the ModelAtlas project."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests
+requests-cache
 beautifulsoup4
 playwright
 huggingface_hub>=0.32.0

--- a/tasks.yml
+++ b/tasks.yml
@@ -760,3 +760,12 @@
   task_id: "REPO-003"
   epic: "Foundational Hardening"
 
+- id: 413
+  title: "Enable caching for scrapers"
+  description: "Integrate requests-cache with CLI toggle and document cache path."
+  component: "Scraper"
+  dependencies: [1, 1.1]
+  priority: 2
+  status: "done"
+  epic: "Data Acquisition"
+

--- a/tasks/tasklog-413-enable-caching-for-scrapers.md
+++ b/tasks/tasklog-413-enable-caching-for-scrapers.md
@@ -1,0 +1,4 @@
+# Task 413: Enable caching for scrapers
+
+## Summary
+Implemented `requests-cache` in scraping scripts with a `--no-cache` flag. Cache stored at `.cache/http.sqlite`. Updated docs and tests.

--- a/tests/test_scrape_ollama.py
+++ b/tests/test_scrape_ollama.py
@@ -4,9 +4,12 @@ import json
 import os
 import sys
 from io import StringIO
+from pathlib import Path
 
-# Add the tools directory to the path so we can import scrape_ollama
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+# Add repo root and tools directory to the path so we can import scrape_ollama
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT_DIR)
+sys.path.insert(0, os.path.join(ROOT_DIR, 'tools'))
 import scrape_ollama
 
 class TestScrapeOllama(unittest.TestCase):
@@ -22,15 +25,18 @@ class TestScrapeOllama(unittest.TestCase):
         scrape_ollama.OLLAMA_MODELS_DIR = self.test_ollama_models_dir
         scrape_ollama.DEBUG_DIR = self.test_debug_dir
         scrape_ollama.LOG_FILE = "test_ollama_scraper.log"
+        scrape_ollama.CACHE_PATH = Path("test_http_cache")
 
-        # Use settings for consistency
-        scrape_ollama.settings.OLLAMA_MODELS_DIR = Path(self.test_ollama_models_dir)
+        scrape_ollama.settings.MODELS_DIR = Path(".")
         scrape_ollama.settings.DEBUG_DIR = Path(self.test_debug_dir)
         scrape_ollama.settings.LOG_FILE = Path("test_ollama_scraper.log")
+        scrape_ollama.settings.PROJECT_ROOT = Path(".")
 
         # Clear log file before each test
         if os.path.exists(scrape_ollama.LOG_FILE):
             os.remove(scrape_ollama.LOG_FILE)
+        if os.path.exists("test_http_cache.sqlite"):
+            os.remove("test_http_cache.sqlite")
 
     def tearDown(self):
         # Clean up temporary directories and files


### PR DESCRIPTION
## Summary
- integrate requests-cache into scrape_hf.py and scrape_ollama.py
- add `--no-cache` flag for both scrapers
- document cache location
- add requirements entry and test adjustments
- log completed task 413

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68789ea6c064832a86a0abed5604eb71