### PR TITLE
Add init command

### DIFF
--- a/atlas_cli/main.py
+++ b/atlas_cli/main.py
@@ -1,62 +1,85 @@
-import argparse
+from __future__ import annotations
+
+import shutil
 import sys
-import json
-import yaml
 from pathlib import Path
+from typing import Optional
+
+import yaml
+import typer
+from rich.console import Console
+from rich.panel import Panel
 
 # Add the project root to sys.path to enable imports from atlas_schemas
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from common.logging import logger
-
 from atlas_schemas.config import settings
 from enrich.main import run_enrichment_trace
 from trustforge.score import compute_and_merge_trust_scores
 
-def main():
-    parser = argparse.ArgumentParser(description="ModelAtlas CLI")
-    parser.add_argument("--input", type=str, help="Input file path")
-    parser.add_argument("--output", type=str, help="Output file path")
-    parser.add_argument("--tasks_yml", type=str, help="Tasks YAML file path")
+app = typer.Typer(help="ModelAtlas CLI")
+console = Console()
 
-    args = parser.parse_args()
 
-    logger.info("Input: %s", args.input)
-    logger.info("Output: %s", args.output)
-    logger.info("Tasks YML: %s", args.tasks_yml)
-
-    # Load tasks from tasks.yml
-    tasks_file_path = Path(args.tasks_yml) if args.tasks_yml else PROJECT_ROOT / "tasks.yml"
+@app.command()
+def trace(
+    input: Optional[Path] = typer.Option(None, help="Input file path"),
+    output: Optional[Path] = typer.Option(None, help="Output file path"),
+    tasks_yml: Optional[Path] = typer.Option(None, help="Tasks YAML file path"),
+) -> None:
+    """Run the enrichment and trust score trace."""
+    tasks_file_path = tasks_yml if tasks_yml else PROJECT_ROOT / "tasks.yml"
     if not tasks_file_path.exists():
         logger.error("tasks.yml not found at %s", tasks_file_path)
-        sys.exit(1)
+        raise typer.Exit(code=1)
 
-    with open(tasks_file_path, "r") as f:
+    with open(tasks_file_path, "r", encoding="utf-8") as f:
         tasks = yaml.safe_load(f)
 
-    # Convert input/output paths to Path objects
-    input_path = Path(args.input) if args.input else settings.MODELS_DIR
-    output_path = Path(args.output) if args.output else (settings.PROJECT_ROOT / settings.OUTPUT_FILE)
+    input_path = input if input else settings.MODELS_DIR
+    output_path = output if output else (settings.PROJECT_ROOT / settings.OUTPUT_FILE)
 
-    # Simple orchestration based on task IDs (this will be expanded)
     for task in tasks:
-        if task["id"] == 2: # Enrich model metadata with LLM (now run_enrichment_trace)
+        if task["id"] == 2:
             logger.info("Executing Task %s: %s", task["id"], task["title"])
             run_enrichment_trace(
                 input_dir=input_path,
                 output_file=output_path,
-                enriched_outputs_dir=settings.ENRICHED_OUTPUTS_DIR
+                enriched_outputs_dir=settings.ENRICHED_OUTPUTS_DIR,
             )
-        elif task["id"] == 10: # Evaluate and rank models by trust and transparency (now compute_and_merge_trust_scores)
+        elif task["id"] == 10:
             logger.info("Executing Task %s: %s", task["id"], task["title"])
             compute_and_merge_trust_scores(
-                input_dir=input_path, # Assuming models are in MODELS_DIR
-                output_file=output_path, # Overwriting for simplicity
-                enriched_outputs_dir=settings.ENRICHED_OUTPUTS_DIR
+                input_dir=input_path,
+                output_file=output_path,
+                enriched_outputs_dir=settings.ENRICHED_OUTPUTS_DIR,
             )
 
     logger.info("Trace execution complete.")
 
+
+@app.command()
+def init() -> None:
+    """Bootstrap local environment by creating a .env file."""
+    env_path = PROJECT_ROOT / ".env"
+    example_path = PROJECT_ROOT / ".env.example"
+    if env_path.exists():
+        console.print(f"[yellow].env already exists at {env_path}[/]")
+    else:
+        shutil.copy(example_path, env_path)
+        console.print(Panel("TRUTH FORGED", style="bold green"))
+        console.print(f"[bold green]Created {env_path} from .env.example[/]")
+
+
+def _run() -> None:
+    args = sys.argv[1:]
+    if args and args[0] in {"init", "trace", "--help", "-h"}:
+        app()
+    else:
+        app(args=["trace"] + args)
+
+
 if __name__ == "__main__":
-    main()
+    _run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ numpy
 scikit-learn
 sentence-transformers
 rich
+typer
 jinja2
 pandas
 matplotlib

--- a/tests/integration/test_full_trace.py
+++ b/tests/integration/test_full_trace.py
@@ -117,9 +117,10 @@ def test_full_trace_execution(sample_input_dir, fixture_tasks_yml, enriched_outp
     command = [
         "python",
         str(ATLAS_CLI_PATH),
+        "trace",
         "--input", str(sample_input_dir),
         "--output", str(output_file),
-        "--tasks_yml", str(fixture_tasks_yml)
+        "--tasks-yml", str(fixture_tasks_yml)
     ]
 
     try:


### PR DESCRIPTION
## Summary
- refactor CLI to use Typer and add `init` command
- show success banner using `rich`
- adjust scraper logging for tests
- update requirements and integration test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878cd3dd38c832abee87dc5278d05dc