### PR TITLE
Add lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    uses: ./.github/workflows/lint.yml
+
+  test:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          playwright install --with-deps
+      - name: Run tests
+        run: pytest
+      - name: Build docs
+        run: make -C docs html

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Lint
+
+on:
+  workflow_call:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          pip install black isort flake8
+      - name: Run black
+        run: black --check .
+      - name: Run isort
+        run: isort --check .
+      - name: Run flake8
+        run: flake8

--- a/tasks.yml
+++ b/tasks.yml
@@ -779,3 +779,19 @@
   status: "done"
   epic: "Refactor"
 
+
+- id: 415
+  title: "Add lint workflow"
+  description: "Create .github/workflows/lint.yml running black --check, isort --check, and flake8; integrate with CI."
+  component: "CI"
+  dependencies: [407]
+  priority: 3
+  status: "done"
+  area: "Automation"
+  actionable_steps:
+    - "Create lint.yml"
+    - "Have ci.yml depend on lint job"
+  acceptance_criteria:
+    - "CI fails on formatting violations"
+  task_id: "CI-002"
+  epic: "Reliability & CI"

--- a/tasks/tasklog-415-add-lint-workflow.md
+++ b/tasks/tasklog-415-add-lint-workflow.md
@@ -1,0 +1,4 @@
+# Task 415: Add lint workflow
+
+## Summary
+Implemented a reusable lint workflow running `black --check`, `isort --check`, and `flake8`. Updated `ci.yml` to call this workflow and only run tests and docs after lint passes.


### PR DESCRIPTION
## Summary
- add GitHub Actions lint workflow running black, isort, and flake8
- integrate lint job with existing CI workflow
- document task completion

## Testing
- `pytest -q`
- `make -C docs html`
- `black --check .` *(fails: files would be reformatted)*
- `isort --check .` *(fails: imports are incorrectly sorted)*
- `flake8` *(fails with many style violations)*

------
https://chatgpt.com/codex/tasks/task_e_6878d69c1c40832a9ce9cd924ad94d41