### PR TITLE
Add testing documentation

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,27 @@
+# Testing Guide
+
+This project uses **pytest** for all automated tests.
+
+## Running the Test Suite
+
+Install the Python dependencies and Playwright browsers first:
+
+```bash
+pip install -r requirements.txt
+playwright install
+```
+
+Then execute the suite quietly with:
+
+```bash
+pytest -q
+```
+
+## Integration Test
+
+A sample end-to-end trace test lives in `tests/integration/test_full_trace.py`.
+Run it directly with:
+
+```bash
+pytest tests/integration/test_full_trace.py -q
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,4 +23,5 @@ documentation for details.
    PHASE_2_DESIGN
    VISUALIZATION_IDEAS
    REPO_AUDIT
+   TESTING
 


### PR DESCRIPTION
## Summary
- document how to run the tests via pytest
- mention Playwright setup
- link the guide from the docs index

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*
- `playwright install` *(fails: command not found)*
- `make -C docs html` *(fails: sphinx-build: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878e31b14c8832a8b0d100b3bea1e48