### PR TITLE
TASK 416: Raise error on missing config keys

### DIFF
--- a/atlas_schemas/config.py
+++ b/atlas_schemas/config.py
@@ -1,6 +1,7 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import model_validator
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List
 
 class Config(BaseSettings):
     """Centralized configuration for the ModelAtlas project."""
@@ -21,9 +22,24 @@ class Config(BaseSettings):
 
     # LLM Enrichment settings
     LLM_API_KEY: Optional[str] = None
+    HUGGING_FACE_API_KEY: Optional[str] = None
+    OPENAI_API_KEY: Optional[str] = None
     LLM_MODEL_NAME: str = "gemini-1.5-pro"
 
+    REQUIRED_KEYS: List[str] = ["LLM_API_KEY"]
+
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    @model_validator(mode="after")
+    def validate_required_keys(cls, values: "Config") -> "Config":
+        missing = [k for k in values.REQUIRED_KEYS if not getattr(values, k)]
+        if missing:
+            missing_str = ", ".join(missing)
+            raise ValueError(
+                f"Missing required configuration keys: {missing_str}. "
+                "Set them in your environment or .env file."
+            )
+        return values
 
 # Create a singleton instance of the Config
 settings = Config()

--- a/tasks.yml
+++ b/tasks.yml
@@ -795,3 +795,20 @@
     - "CI fails on formatting violations"
   task_id: "CI-002"
   epic: "Reliability & CI"
+
+- id: 416
+  title: "Raise error on missing config keys"
+  description: "Update atlas_schemas/config.py to raise a helpful error if required keys are missing."
+  component: "Config"
+  dependencies: [201]
+  priority: 2
+  status: "done"
+  area: "Bugfix"
+  actionable_steps:
+    - "Add validation for required environment variables in Config"
+    - "Write tests for missing key scenarios"
+  acceptance_criteria:
+    - "Config initialization fails with clear error when LLM_API_KEY is absent"
+    - "tests/test_config.py passes"
+  task_id: "CONFIG-002"
+  epic: "Foundational Hardening"

--- a/tasks/tasklog-416-raise-error-on-missing-config-keys.md
+++ b/tasks/tasklog-416-raise-error-on-missing-config-keys.md
@@ -1,0 +1,7 @@
+# Task 416: Raise error on missing config keys
+
+## Summary
+- Added validation to `atlas_schemas.config.Config` to check for required environment variables.
+- Instantiation now raises a `ValueError` listing missing keys with guidance to update the `.env` file.
+- Created `tests/test_config.py` to cover success and failure scenarios.
+- Updated `tests/test_scrape_ollama.py` to set required keys for existing tests.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,16 @@
+import pytest
+
+from atlas_schemas.config import Config
+
+
+def test_config_missing_required_key(monkeypatch):
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    with pytest.raises(ValueError) as exc:
+        Config()
+    assert "LLM_API_KEY" in str(exc.value)
+
+
+def test_config_initialization_with_key(monkeypatch):
+    monkeypatch.setenv("LLM_API_KEY", "dummy")
+    cfg = Config()
+    assert cfg.LLM_API_KEY == "dummy"

--- a/tests/test_scrape_ollama.py
+++ b/tests/test_scrape_ollama.py
@@ -11,6 +11,11 @@ ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, ROOT_DIR)
 sys.path.insert(0, os.path.join(ROOT_DIR, 'tools'))
 
+# Ensure required config keys for tests
+os.environ.setdefault("LLM_API_KEY", "dummy")
+os.environ.setdefault("HUGGING_FACE_API_KEY", "dummy")
+os.environ.setdefault("OPENAI_API_KEY", "dummy")
+
 import scrape_ollama
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- update atlas_schemas/config.py to enforce required env vars
- extend tests with config error cases
- ensure existing tests set dummy API keys
- document completion of task 416

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68791d1f63c4832aa2aebca8b4e84789