### PR TITLE
Introduce .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,8 @@ To maintain consistency and clarity across the project, please adhere to the fol
 - Follow PEP8 for Python
 - Use Jinja2 for templating
 - Ensure JSON schema compliance
+- The repository includes a `.editorconfig` file. Configure your editor to honor
+  it so all files are saved as UTF-8 and end with a newline.
 
 ## Pull Requests
 - Write tests for new features


### PR DESCRIPTION
## Summary
- add repo-wide `.editorconfig` enforcing UTF‑8 and newline at EOF
- mention the new config in CONTRIBUTING

## Checklist
- [x] Tests pass locally (`pytest`)
- [ ] Linting and formatting applied
- [x] Documentation updated as needed

## Related Issues
Fixes #

------
https://chatgpt.com/codex/tasks/task_e_687921068484832aa333154f6135a6f6