### PR TITLE
Refactor CLI into package

### DIFF
--- a/atlas_cli/main.py
+++ b/atlas_cli/main.py
@@ -23,13 +23,17 @@ app = typer.Typer(help="ModelAtlas CLI")
 console = Console()
 
 
-@app.command()
+@app.command(help="Run the enrichment and trust score trace.")
 def trace(
     input: Optional[Path] = typer.Option(None, help="Input file path"),
     output: Optional[Path] = typer.Option(None, help="Output file path"),
     tasks_yml: Optional[Path] = typer.Option(None, help="Tasks YAML file path"),
 ) -> None:
-    """Run the enrichment and trust score trace."""
+    """Run the enrichment and trust score trace.
+
+    Examples:
+        python -m atlas_cli.main trace --input models --output result.json
+    """
     tasks_file_path = tasks_yml if tasks_yml else PROJECT_ROOT / "tasks.yml"
     if not tasks_file_path.exists():
         logger.error("tasks.yml not found at %s", tasks_file_path)
@@ -60,9 +64,13 @@ def trace(
     logger.info("Trace execution complete.")
 
 
-@app.command()
+@app.command(help="Bootstrap local environment by creating a .env file.")
 def init() -> None:
-    """Bootstrap local environment by creating a .env file."""
+    """Bootstrap local environment by creating a .env file.
+
+    Example:
+        python -m atlas_cli.main init
+    """
     env_path = PROJECT_ROOT / ".env"
     example_path = PROJECT_ROOT / ".env.example"
     if env_path.exists():

--- a/docs/usage_examples.md
+++ b/docs/usage_examples.md
@@ -10,3 +10,44 @@ python enrich/main.py --limit 10
 atlas-cli search llama
 ```
 
+## Command Help
+
+```bash
+$ python -m atlas_cli.main --help
+Usage: python -m atlas_cli.main [OPTIONS] COMMAND [ARGS]...
+
+ ModelAtlas CLI
+
+Options:
+  --install-completion  Install completion for the current shell.
+  --show-completion     Show completion for the current shell, to copy it or customize the installation.
+  --help                Show this message and exit.
+
+Commands:
+  trace  Run the enrichment and trust score trace.
+  init   Bootstrap local environment by creating a .env file.
+```
+
+```bash
+$ python -m atlas_cli.main trace --help
+Usage: python -m atlas_cli.main trace [OPTIONS]
+
+Run the enrichment and trust score trace.
+
+Options:
+  --input PATH      Input file path
+  --output PATH     Output file path
+  --tasks-yml PATH  Tasks YAML file path
+  --help            Show this message and exit.
+```
+
+```bash
+$ python -m atlas_cli.main init --help
+Usage: python -m atlas_cli.main init [OPTIONS]
+
+Bootstrap local environment by creating a .env file.
+
+Options:
+  --help  Show this message and exit.
+```
+

--- a/tasks.yml
+++ b/tasks.yml
@@ -649,7 +649,7 @@
   component: "CLI"
   dependencies: []
   priority: 3
-  status: "pending"
+  status: "done"
   area: "Refactor"
   actionable_steps:
     - "Create atlas_cli/__init__.py and atlas_cli/main.py"

--- a/tasks/tasklog-406-refactor-cli-into-package.md
+++ b/tasks/tasklog-406-refactor-cli-into-package.md
@@ -1,0 +1,8 @@
+# Task 406: Refactor CLI into package
+
+## Summary
+Finalized Typer-based CLI and documented usage. Added command help snippets and clarified options.
+
+## Notes
+- Each command now includes examples in the docstring.
+- `docs/usage_examples.md` shows `--help` output for quick reference.


### PR DESCRIPTION
## Summary
- improve CLI command help and add usage examples
- embed `--help` output snippets in the docs
- mark CLI refactor task as complete

## Testing
- `pytest -q`
- `make -C docs html`

------
https://chatgpt.com/codex/tasks/task_e_68792ee999d4832abdced54c74332b53