### PR TITLE
Add unit tests for atlas_cli.search module

### DIFF
--- a/atlas_cli/main.py
+++ b/atlas_cli/main.py
@@ -18,6 +18,7 @@ from common.logging import logger
 from atlas_schemas.config import settings
 from enrich.main import run_enrichment_trace
 from trustforge.score import compute_and_merge_trust_scores
+from atlas_cli.search import cli as search_cli
 
 app = typer.Typer(help="ModelAtlas CLI")
 console = Console()
@@ -79,6 +80,12 @@ def init() -> None:
         shutil.copy(example_path, env_path)
         console.print(Panel("TRUTH FORGED", style="bold green"))
         console.print(f"[bold green]Created {env_path} from .env.example[/]")
+
+
+@app.command(help="Search models by name and summary")
+def search(query: str, top_k: int = typer.Option(5, help="Number of results")) -> None:
+    """Search the local model catalog."""
+    search_cli(query=query, top_k=top_k)
 
 
 def _run() -> None:

--- a/atlas_cli/search.py
+++ b/atlas_cli/search.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from typing import List, Dict
+import json
+
+from rich.console import Console
+from rich.table import Table
+
+from atlas_schemas.config import settings
+
+CATALOG_PATH = settings.PROJECT_ROOT / "models_enriched.json"
+console = Console()
+
+def load_models(catalog_path: Path = CATALOG_PATH) -> List[Dict]:
+    """Load models from the given JSON file."""
+    if not catalog_path.exists():
+        console.print(f"[bold red]Catalog not found at {catalog_path}.[/]")
+        return []
+    with open(catalog_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+def search_models(query: str, models: List[Dict], top_k: int = 5) -> List[Dict]:
+    """Return top_k models matching the query."""
+    if not models:
+        return []
+    q = query.lower()
+    scored = []
+    for m in models:
+        text = f"{m.get('name', '')} {m.get('summary', '')}".lower()
+        if q in text:
+            score = text.count(q)
+            scored.append((score, m))
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [m for _, m in scored[:top_k]]
+
+def display_results(models: List[Dict]) -> None:
+    """Pretty print matching models."""
+    table = Table(title="Matching Models")
+    table.add_column("Name", style="cyan")
+    table.add_column("Summary", style="green")
+    for m in models:
+        table.add_row(m.get("name", "?"), m.get("summary", "")[:50])
+    console.print(table)
+
+def cli(query: str, top_k: int = 5, catalog: Path = CATALOG_PATH) -> None:
+    """Search models in the catalog and display results."""
+    models = load_models(catalog)
+    results = search_models(query, models, top_k=top_k)
+    if results:
+        display_results(results)
+    else:
+        console.print("[bold yellow]No matches found.[/]")

--- a/tasks.yml
+++ b/tasks.yml
@@ -812,3 +812,19 @@
     - "tests/test_config.py passes"
   task_id: "CONFIG-002"
   epic: "Foundational Hardening"
+
+- id: 417
+  title: "Write CLI search tests"
+  description: "Add unit tests for atlas_cli.search module"
+  component: "Testing"
+  dependencies: []
+  priority: 2
+  status: "done"
+  area: "Testing"
+  actionable_steps:
+    - "Create atlas_cli/search.py with basic search logic"
+    - "Write pytest tests covering query patterns"
+  acceptance_criteria:
+    - "pytest coverage shows >80% for atlas_cli/search.py"
+  task_id: "CLI-TEST-001"
+  epic: "Reliability & CI"

--- a/tasks/tasklog-417-write-cli-search-tests.md
+++ b/tasks/tasklog-417-write-cli-search-tests.md
@@ -1,0 +1,8 @@
+# Task 417: Write CLI search tests
+
+## Summary
+Implemented a lightweight search module and accompanying tests. Added a Typer command to expose the search feature via the CLI and ensured coverage exceeds 80%.
+
+## Notes
+- search.load_models prints a helpful message when the catalog is missing.
+- pytest now includes tests for load_models, search_models and the CLI entry point.

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,38 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT_DIR)
+
+from atlas_cli import search
+
+
+def test_load_models_missing(tmp_path, capsys):
+    path = tmp_path / "missing.json"
+    models = search.load_models(path)
+    captured = capsys.readouterr()
+    assert models == []
+    assert "Catalog not found" in captured.out
+
+
+def test_search_models_basic():
+    data = [
+        {"name": "llama3", "summary": "great model"},
+        {"name": "mistral", "summary": "fast model"},
+        {"name": "tiny-llama", "summary": "small"},
+    ]
+    results = search.search_models("llama", data, top_k=2)
+    assert [m["name"] for m in results] == ["llama3", "tiny-llama"]
+
+
+def test_cli_outputs(monkeypatch):
+    sample = [{"name": "llama3", "summary": "great"}]
+    monkeypatch.setattr(search, "load_models", lambda catalog: sample)
+    console = search.Console(record=True)
+    monkeypatch.setattr(search, "console", console)
+    search.cli("llama")
+    output = console.export_text()
+    assert "llama3" in output


### PR DESCRIPTION
## Summary
- create `atlas_cli/search.py` and expose a `search` command via Typer
- test `search.load_models`, `search.search_models`, and CLI output
- log completion of Task 417 in tasks.yml and tasklog

## Testing
- `pytest -q`
- `pytest --cov=atlas_cli.search --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_e_6879e82ebe00832aa349fc6b665734dd