### PR TITLE
Add Dockerfile with Playwright

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt \
+    && playwright install --with-deps
+COPY . .
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,27 @@ Run `make test-deps` if you need all packages for the test suite.
 
 `enrich/main.py` runs the enrichment trace, and CLI commands reside in the `atlas_cli/` package.
 
+## 🐳 Docker Usage
+
+Build a container with all Python dependencies and Playwright browsers preinstalled:
+
+```bash
+docker build -t modelatlas .
+```
+
+Launch an interactive shell inside the container:
+
+```bash
+docker run --rm -it modelatlas
+```
+
+You can then run the enrichment trace or CLI tools just as on the host system:
+
+```bash
+python enrich/main.py
+atlas search "llama"
+```
+
 ⸻
 
 ## 🧠 System Overview


### PR DESCRIPTION
## Summary
- add minimal Dockerfile to install dependencies and Playwright
- document container usage in README

## Testing
- `pip install -r requirements.txt` *(runs successfully)*
- `playwright install` *(fails: missing system dependencies)*
- `make -C docs html`
- `pytest` *(fails: missing required configuration key LLM_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_687a4ad3cfdc832aa4a7a8b6b31ca96a