### PR TITLE
Add env variable docs and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Create a `.env` file for API keys:
 cp .env.example .env  # or run `atlas init`
 ```
 
+The resulting `.env` file holds configuration keys such as
+`LLM_API_KEY`, `OPENAI_API_KEY`, `HUGGING_FACE_API_KEY`, and the optional
+`PLAYWRIGHT_BROWSERS_PATH`. Populate these values before running the
+enrichment pipeline or CLI tools.
+
 Run `make test-deps` if you need all packages for the test suite.
 
 `enrich/main.py` runs the enrichment trace, and CLI commands reside in the `atlas_cli/` package.

--- a/atlas_schemas/config.py
+++ b/atlas_schemas/config.py
@@ -24,6 +24,7 @@ class Config(BaseSettings):
     LLM_API_KEY: Optional[str] = None
     HUGGING_FACE_API_KEY: Optional[str] = None
     OPENAI_API_KEY: Optional[str] = None
+    PLAYWRIGHT_BROWSERS_PATH: Optional[str] = None
     LLM_MODEL_NAME: str = "gemini-1.5-pro"
 
     REQUIRED_KEYS: List[str] = ["LLM_API_KEY"]


### PR DESCRIPTION
## Summary
- mention `.env` variables in README
- include `PLAYWRIGHT_BROWSERS_PATH` in config schema

## Testing
- `pip install -r requirements.txt`
- `playwright install` *(fails: Host system is missing dependencies)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ad3e7a724832ab914794588e8b03c