### PR TITLE
Implement pre-commit lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,10 +17,6 @@ jobs:
           python-version: "3.11"
       - name: Install dependencies
         run: |
-          pip install black isort flake8
-      - name: Run black
-        run: black --check .
-      - name: Run isort
-        run: isort --check .
-      - name: Run flake8
-        run: flake8
+          pip install pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+        args: ["--line-length=88"]
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args: ["--profile=black"]
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ included automatically. Add new docs as `.md` files and list them in
 The repository uses a comprehensive `.gitignore` based on common Python patterns.
 Ensure all scripts open files with `encoding='utf-8'` for consistent behavior across platforms.
 Install dependencies with `pip install -r requirements.txt && playwright install` before running the examples.
+Install `pre-commit` with `pip install pre-commit` and run `pre-commit install` so Git hooks enforce formatting locally. The lint workflow runs `pre-commit`, so ensure hooks pass before pushing.
 
 ### Git LFS Workaround
 
@@ -85,7 +86,7 @@ This silences status noise. Long term we should host large artifacts externally
 (for example S3 or HuggingFace Datasets) and keep only pointers to stable
 releases in this repo.
 
-## Insights 
+## Insights
 
 If an agent receives a refusal like "I'm sorry, but I can't help with that," it must assess:
 - (a) whether the request is blocked due to model alignment tuning,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@
 3. Install dependencies: `pip install -r requirements.txt` (includes packages like `playwright`, `beautifulsoup4`, and `requests` used by the test suite)
 4. Install Playwright browsers: `playwright install`
 5. Optionally run `make test-deps` to perform both steps at once
+6. Install pre-commit hooks: `pip install pre-commit && pre-commit install`
 
 ## Development
 - **Scraper**: `python tools/scrape_*.py`
@@ -36,4 +37,3 @@ Please open bug reports and feature requests using the templates in `.github/ISS
 
 ## Running Tests
 Run `pytest` from the repository root. Ensure the dependencies in requirements.txt are installed and browsers are set up via `playwright install`.
-

--- a/tasks.yml
+++ b/tasks.yml
@@ -733,7 +733,7 @@
   component: "Repo"
   dependencies: [405]
   priority: 3
-  status: "pending"
+  status: "done"
   area: "Automation"
   actionable_steps:
     - "Add pre-commit configuration with black/isort"

--- a/tasks/tasklog-411-implement-pre-commit-hooks.md
+++ b/tasks/tasklog-411-implement-pre-commit-hooks.md
@@ -1,0 +1,7 @@
+# Task 411: Implement pre-commit hooks
+
+## Summary
+- Added `.pre-commit-config.yaml` with black, isort, flake8 and basic whitespace fixers.
+- Updated `lint` workflow to run `pre-commit` instead of individual linters.
+- Documented hook setup in `CONTRIBUTING.md` and added guidance in `AGENTS.md`.
+- Marked task 411 as done in `tasks.yml`.


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml`
- update lint workflow to run `pre-commit`
- document hook setup in AGENTS and CONTRIBUTING
- mark task 411 complete and add log

## Testing
- `pre-commit run --files .pre-commit-config.yaml .github/workflows/lint.yml AGENTS.md CONTRIBUTING.md tasks.yml tasks/tasklog-411-implement-pre-commit-hooks.md`
- `PYTHONPATH=. pytest --cov=trustforge --cov=similarity_engine`

------
https://chatgpt.com/codex/tasks/task_e_687ad94199f4832a80e4a3a33a92d975