### PR TITLE
Add schema validation test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ sphinx
 recommonmark
 pytest
 pytest-asyncio
+jsonschema
+pytest-cov

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+
+import pytest
+
+try:
+    import jsonschema
+except ImportError:  # pragma: no cover - install in CI
+    jsonschema = None
+
+
+@pytest.mark.skipif(jsonschema is None, reason="jsonschema package not available")
+def test_models_validate_against_schema():
+    repo_root = Path(__file__).resolve().parents[1]
+    data_file = repo_root / "data" / "models_validated.json"
+    schema_file = repo_root / "schemas" / "model.schema.json"
+
+    if not data_file.exists():
+        pytest.skip(f"{data_file} not present")
+    if not schema_file.exists():
+        pytest.skip("schema file missing")
+
+    data = json.loads(data_file.read_text(encoding="utf-8"))
+    schema = json.loads(schema_file.read_text(encoding="utf-8"))
+
+    assert isinstance(data, list), "validated models should be a list"
+    for entry in data:
+        jsonschema.validate(entry, schema)


### PR DESCRIPTION
## Summary
- add `jsonschema` and `pytest-cov` to requirements
- add `tests/test_schema_validation.py` to validate `data/models_validated.json`

## Testing
- `pip install -r requirements.txt`
- `playwright install` *(fails: missing system libraries)*
- `PYTHONPATH=. pytest --cov=trustforge --cov=similarity_engine`

------
https://chatgpt.com/codex/tasks/task_e_687adfe46528832a8a141075d0f65e61