### PR TITLE
Implement pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,15 +4,22 @@ repos:
     hooks:
       - id: black
         args: ["--line-length=88"]
+        files: "\\.py$"
+        exclude: "data/|enriched_outputs/"
+        language_version: python3
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile=black"]
+        files: "\\.py$"
+        exclude: "data/|enriched_outputs/"
+        language_version: python3
   - repo: https://github.com/pycqa/flake8
     rev: 6.1.0
     hooks:
       - id: flake8
+        language_version: python3
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@
 4. Install Playwright browsers: `playwright install`
 5. Optionally run `make test-deps` to perform both steps at once
 6. Install pre-commit hooks: `pip install pre-commit && pre-commit install`
+7. Run the hook suite manually with `pre-commit run --all-files` to ensure formatting passes before pushing
 
 ## Development
 - **Scraper**: `python tools/scrape_*.py`


### PR DESCRIPTION
## Summary
- configure black and isort hook options
- document running the hooks in `CONTRIBUTING.md`

## Testing
- `pre-commit run --files .pre-commit-config.yaml CONTRIBUTING.md`
- `pytest`
- `make -C docs html`

------
https://chatgpt.com/codex/tasks/task_e_687adf7a77fc832aa881bde0db025c34