### PR TITLE
Add community governance docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Contributor Covenant Code of Conduct
+
+This project adopts the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) in full.
+We expect everyone to help create a welcoming and harassment-free environment.
+
+## Enforcement
+
+Report unacceptable behavior to [security@modelatlas.ai](mailto:security@modelatlas.ai).
+All reports will be reviewed and kept confidential.

--- a/HUMANS.md
+++ b/HUMANS.md
@@ -27,6 +27,7 @@ This direction transforms ModelAtlas from an assembly line into a system that mo
 
 
 Contributors should use the new GitHub issue and PR templates for all submissions.
+Community policies are documented in `CODE_OF_CONDUCT.md` and `SECURITY.md`.
 
 ## README Generation
 The root README is rendered from `templates/README.md.j2` by running `python generate_readme.py`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌐 **ModelAtlas**  
+# 🌐 **ModelAtlas**
 ### *Map the Modelverse. Trace the Truth. Shape the Future.*
 
 ⸻
@@ -87,7 +87,7 @@ flowchart TD
 ### `atlas-cli` — 🌐 Semantic Search Interface
 - Enables powerful search across enriched model metadata fields.
 - Supports embeddings, advanced filters, and fuzzy matching techniques.
-- Example usage:  
+- Example usage:
   ```bash
   atlas search "open model for code completion"
   ```
@@ -112,7 +112,7 @@ flowchart TD
   - Config blob origins
   - Step-by-step enrichment history
   - Prompt decision trees and rationale
-- Usage example:  
+- Usage example:
   ```bash
   tracepoint llama3:8b --lineage
   ```
@@ -228,6 +228,8 @@ All files in `data/` and `enriched_outputs/` are tracked via LFS, so new assets 
 | `schema.md`          | Data schema specification for enriched model entries |
 | `usage_examples.md`  | Real-world CLI traces and usage patterns |
 | `PHASE_2_DESIGN.md`  | Design notes on manifest decoding, tag repair, and scoring implementation |
+| `CODE_OF_CONDUCT.md` | Community expectations and enforcement policy |
+| `SECURITY.md`        | How to report vulnerabilities |
 
 ⸻
 
@@ -235,14 +237,14 @@ All files in `data/` and `enriched_outputs/` are tracked via LFS, so new assets 
 
 ModelAtlas is founded on these core principles:
 
-- 🔎 *Transparency over Obfuscation*  
-- ♻️ *Recursive Enrichment is Integral, Not Optional*  
-- 🛡️ *Trust Must Be Quantifiable and Measurable*  
-- 🧠 *LLMs Are Tools That Can Self-Improve and Assist*  
+- 🔎 *Transparency over Obfuscation*
+- ♻️ *Recursive Enrichment is Integral, Not Optional*
+- 🛡️ *Trust Must Be Quantifiable and Measurable*
+- 🧠 *LLMs Are Tools That Can Self-Improve and Assist*
 
 We hold that metadata is critical infrastructure, and that systems should be able to explain their own construction with clarity and rigor.
 
 ⸻
 
-> **Map the modelscape. Trace the truth. Shape the future.**  
+> **Map the modelscape. Trace the truth. Shape the future.**
 > 🧭 *Welcome to the Atlas.*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please email [security@modelatlas.ai](mailto:security@modelatlas.ai) with details of any potential vulnerabilities.
+You may also open a private security advisory on GitHub.
+We aim to respond within 72 hours.

--- a/tasks.yml
+++ b/tasks.yml
@@ -904,3 +904,21 @@
     - "pytest coverage shows >80% for atlas_cli/search.py"
   task_id: "CLI-TEST-001"
   epic: "Reliability & CI"
+
+- id: 423
+  title: "Add community governance docs"
+  description: "Create CODE_OF_CONDUCT and SECURITY policy with vulnerability reporting."
+  component: "Repo"
+  dependencies: []
+  priority: 1
+  status: "done"
+  area: "Governance"
+  actionable_steps:
+    - "Write CODE_OF_CONDUCT.md referencing Contributor Covenant"
+    - "Draft SECURITY.md with reporting instructions"
+    - "Link both documents from README"
+  acceptance_criteria:
+    - "CODE_OF_CONDUCT.md and SECURITY.md exist"
+    - "README references the new docs"
+  task_id: "GOV-002"
+  epic: "Foundational Hardening"

--- a/tasks/tasklog-423-add-community-governance-docs.md
+++ b/tasks/tasklog-423-add-community-governance-docs.md
@@ -1,0 +1,4 @@
+# Task 423: Add community governance docs
+
+## Summary
+Created CODE_OF_CONDUCT.md and SECURITY.md. Updated README to reference them and noted enforcement contact.


### PR DESCRIPTION
## Summary
- introduce CODE_OF_CONDUCT.md adapted from the Contributor Covenant
- create SECURITY.md covering vulnerability reporting
- reference both docs in README
- log work in tasks.yml and tasklog
- note docs in HUMANS guidance

## Testing
- `pre-commit run --files README.md CODE_OF_CONDUCT.md SECURITY.md tasks.yml tasks/tasklog-423-add-community-governance-docs.md HUMANS.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b2d1f4a68832a8c295e3bf0301ad3